### PR TITLE
Line Break Character

### DIFF
--- a/lib/xmlss/data.rb
+++ b/lib/xmlss/data.rb
@@ -3,7 +3,7 @@ require 'date'
 module Xmlss
   class Data
 
-    LB = "&#13;"
+    LB = "&#13;&#10;"
 
     include Xmlss::Xml
     def xml


### PR DESCRIPTION
The line break character of `&#13;` works in excel 2008, but in 2007 it expects the character `&#10;`. I've changed it so that both `&#13;&#10;` will replace a `\n` or `\r` character.

Also, can you update osheet's version of xmlss to use this?
