### PR TITLE
Font name styling

### DIFF
--- a/lib/xmlss/style/font.rb
+++ b/lib/xmlss/style/font.rb
@@ -5,7 +5,8 @@ module Xmlss::Style
       { :node => :font,
         :attributes => [
           :bold, :color, :italic, :size, :shadow,
-          :strike_through, :underline, :vertical_align
+          :strike_through, :underline, :vertical_align,
+          :font_name
         ] }
     end
 
@@ -22,7 +23,8 @@ module Xmlss::Style
     }
     alias_method :vertical_align, :alignment
 
-    attr_accessor :bold, :color, :italic, :size, :strike_through, :shadow
+    attr_accessor :bold, :color, :italic, :size, :strike_through, :shadow, :name
+    alias :font_name :name
 
     def initialize(attrs={})
       self.bold = attrs[:bold] || false
@@ -33,6 +35,7 @@ module Xmlss::Style
       self.shadow = attrs[:shadow] || false
       self.underline = attrs[:underline]
       self.alignment = attrs[:alignment]
+      self.name = attrs[:name]
     end
 
     def bold?; !!self.bold; end

--- a/test/style/font_test.rb
+++ b/test/style/font_test.rb
@@ -32,7 +32,7 @@ module Xmlss::Style
     end
 
     should have_accessors :bold, :color, :italic, :size, :strike_through, :shadow
-    should have_accessors :underline, :alignment
+    should have_accessors :underline, :alignment, :name
     should have_instance_methods :bold?, :italic?, :strike_through?, :shadow?
     should have_reader :vertical_align
 
@@ -45,6 +45,7 @@ module Xmlss::Style
       assert_equal false, subject.shadow
       assert_equal nil, subject.underline
       assert_equal nil, subject.alignment
+      assert_equal nil, subject.name
     end
 
     should "set attrs at init" do
@@ -55,7 +56,8 @@ module Xmlss::Style
         :size => 10,
         :strike_through => true,
         :underline => :single,
-        :alignment => :superscript
+        :alignment => :superscript,
+        :name => 'Verdana'
       }
       font = Font.new(attrs)
 


### PR DESCRIPTION
Allowing the setting of the font_name attribute on the font styles through the accessor name.  Added tests.
